### PR TITLE
chore: Add stuffz to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
+# Editor specifi files/folders:
+*.swp
 .vscode
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -103,7 +106,7 @@ celerybeat.pid
 *.sage.py
 
 # Environments
-.env
+.env*
 .venv
 env/
 venv/


### PR DESCRIPTION
`*.swp` -> Vim
`.env*` -> `.envrc` files for hiding sensitive secrets as environment variables (config-as-code) that should _*NOT*_ be checked into git.